### PR TITLE
fix(typecheck): use correct node version in GH workflow

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Set correct lts version in typecheck workflow