### PR TITLE
feat(worktree): auto-cleanup merged worktrees on git pull

### DIFF
--- a/.github/skills/git-worktree/SKILL.md
+++ b/.github/skills/git-worktree/SKILL.md
@@ -78,21 +78,43 @@ Push the branch from inside the worktree directory, then open a PR against `main
 
 ### 5. Clean Up After Merge
 
-Once the PR is merged:
+Cleanup happens **automatically** when you pull merged changes into main:
 
 ```bash
 # Return to the main checkout
 cd /Users/raghibhasan/Documents/open-source/gym
 
-# Remove the worktree
-git worktree remove ../gym-feat-add-workout-timer
-
-# Delete the local branch
-git branch -d feat/add-workout-timer
-
-# Pull the merged changes
+# Pull — the post-merge hook auto-removes merged worktrees
 git pull origin main
 ```
+
+The `post-merge` husky hook runs `scripts/cleanup-merged-worktrees.sh --force`,
+which detects worktrees whose branches are merged into main or whose remote
+tracking branch was deleted (e.g., after a squash-merge on GitHub) and removes
+them along with the local branch.
+
+You can also run cleanup manually at any time:
+
+```bash
+# Interactive (confirms before removing)
+bun run worktree:cleanup
+
+# Non-interactive
+bash scripts/cleanup-merged-worktrees.sh --force
+```
+
+<details>
+<summary>Manual cleanup (if you prefer doing it by hand)</summary>
+
+```bash
+cd /Users/raghibhasan/Documents/open-source/gym
+
+git worktree remove ../gym-feat-add-workout-timer
+git branch -d feat/add-workout-timer
+git pull origin main
+```
+
+</details>
 
 ### 6. Prune Stale Worktrees
 

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -8,7 +8,7 @@ branch="$(git rev-parse --abbrev-ref HEAD)"
 
 if [ "$branch" = "main" ]; then
   script="$(git rev-parse --show-toplevel)/scripts/cleanup-merged-worktrees.sh"
-  if [ -x "$script" ]; then
-    "$script" --force
+  if [ -f "$script" ]; then
+    bash "$script" --force
   fi
 fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+# After pulling merged changes into main, automatically clean up
+# worktrees whose branches have been merged or deleted on the remote.
+# Uses --force so the hook doesn't block on interactive prompts.
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "main" ]; then
+  script="$(git rev-parse --show-toplevel)/scripts/cleanup-merged-worktrees.sh"
+  if [ -x "$script" ]; then
+    "$script" --force
+  fi
+fi

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "generate-types": "supabase gen types typescript --project-id \"$EXPO_PUBLIC_SUPABASE_PROJECT_ID\" --schema public > src/lib/database.types.ts",
     "db:migrate": "supabase db push",
     "db:reset": "supabase db reset",
+    "worktree:cleanup": "bash scripts/cleanup-merged-worktrees.sh",
     "prepare": "husky"
   },
   "jest": {

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -63,8 +63,13 @@ while IFS= read -r line; do
 
     # Check 2: Does the remote tracking branch still exist?
     # (GitHub deletes branches after squash-merge by default)
-    if [[ "$should_remove" == false ]] && ! git rev-parse --verify "refs/remotes/origin/$wt_branch" &>/dev/null; then
-      should_remove=true
+    if [[ "$should_remove" == false ]]; then
+      # Only consider this check if the branch actually has an upstream configured.
+      # Resolve "$wt_branch@{upstream}" to its full ref name; ignore errors if no upstream.
+      upstream_ref="$(git rev-parse --abbrev-ref "${wt_branch}@{upstream}" 2>/dev/null || true)"
+      if [[ -n "$upstream_ref" ]] && ! git rev-parse --verify "$upstream_ref" &>/dev/null; then
+        should_remove=true
+      fi
     fi
 
     if [[ "$should_remove" == true && -n "${wt_path:-}" && -n "${wt_branch:-}" ]]; then

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -57,7 +57,7 @@ while IFS= read -r line; do
     should_remove=false
 
     # Check 1: Is the branch merged into main?
-    if git branch --merged main 2>/dev/null | grep -qw "$wt_branch"; then
+    if git branch --merged main --format='%(refname:short)' 2>/dev/null | grep -Fxq "$wt_branch"; then
       should_remove=true
     fi
 

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -28,6 +28,42 @@ fi
 
 CURRENT_BRANCH="$(git branch --show-current)"
 
+# Hard guard: this script must be run from the main worktree on branch 'main'
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "ERROR: cleanup-merged-worktrees.sh must be run from the main worktree on branch 'main'."
+  exit 1
+fi
+
+MAIN_WORKTREE_PATH=""
+wt_path=""
+wt_branch=""
+while IFS= read -r line; do
+  if [[ "$line" == worktree\ * ]]; then
+    wt_path="${line#worktree }"
+  elif [[ "$line" == branch\ * ]]; then
+    wt_branch="${line#branch refs/heads/}"
+  elif [[ -z "$line" ]]; then
+    if [[ "${wt_branch:-}" == "main" ]]; then
+      MAIN_WORKTREE_PATH="$wt_path"
+      break
+    fi
+    wt_path=""
+    wt_branch=""
+  fi
+done < <(git worktree list --porcelain; echo "")
+
+if [[ -z "$MAIN_WORKTREE_PATH" ]]; then
+  echo "ERROR: Could not determine the main worktree path for branch 'main'."
+  exit 1
+fi
+
+if [[ "$MAIN_REPO" != "$MAIN_WORKTREE_PATH" ]]; then
+  echo "ERROR: cleanup-merged-worktrees.sh must be run from the main worktree at:"
+  echo "  $MAIN_WORKTREE_PATH"
+  echo "Current working tree is:"
+  echo "  $MAIN_REPO"
+  exit 1
+fi
 # Prune remote tracking refs so deleted remote branches are detected
 git fetch --prune --quiet 2>/dev/null || true
 

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -112,11 +112,12 @@ for i in "${!TO_REMOVE_PATHS[@]}"; do
 
   echo "Removing worktree: $wt_path ($wt_branch)"
 
-  # Remove the worktree directory
+  # Remove the worktree directory via git; if this fails, do not fall back to rm -rf.
   git worktree remove "$wt_path" --force 2>/dev/null || {
-    echo "  ⚠ Could not remove worktree at $wt_path — removing directory manually"
-    rm -rf "$wt_path"
-    git worktree prune
+    echo "  ⚠ Could not remove worktree at $wt_path."
+    echo "    Please inspect and remove this worktree directory manually if appropriate,"
+    echo "    and run 'git worktree prune' once you have cleaned it up."
+    continue
   }
 
   # Delete the local branch

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# cleanup-merged-worktrees.sh
+#
+# Removes git worktrees whose branches have been merged into main
+# (or whose remote tracking branch no longer exists after a squash-merge).
+#
+# Usage:
+#   ./scripts/cleanup-merged-worktrees.sh          # interactive (confirms each removal)
+#   ./scripts/cleanup-merged-worktrees.sh --force   # non-interactive (removes without prompting)
+#
+# Designed to run from the main checkout (the primary workspace directory).
+# Also invoked automatically by the post-merge husky hook after `git pull`.
+
+set -euo pipefail
+
+FORCE=false
+if [[ "${1:-}" == "--force" ]]; then
+  FORCE=true
+fi
+
+# Resolve the main repo root (the git common dir for all worktrees)
+MAIN_REPO="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$MAIN_REPO" ]]; then
+  echo "Not inside a git repository."
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+
+# Prune remote tracking refs so deleted remote branches are detected
+git fetch --prune --quiet 2>/dev/null || true
+
+# Collect worktrees to clean up
+declare -a TO_REMOVE_PATHS=()
+declare -a TO_REMOVE_BRANCHES=()
+
+while IFS= read -r line; do
+  # git worktree list --porcelain outputs blocks like:
+  #   worktree /path/to/worktree
+  #   HEAD abc123
+  #   branch refs/heads/feat/xyz
+  #   <blank line>
+  if [[ "$line" == worktree\ * ]]; then
+    wt_path="${line#worktree }"
+  elif [[ "$line" == branch\ * ]]; then
+    wt_branch="${line#branch refs/heads/}"
+  elif [[ -z "$line" ]]; then
+    # End of a worktree block — evaluate it
+    # Skip the main worktree
+    if [[ "${wt_branch:-main}" == "main" || "${wt_path:-}" == "$MAIN_REPO" ]]; then
+      wt_path=""
+      wt_branch=""
+      continue
+    fi
+
+    should_remove=false
+
+    # Check 1: Is the branch merged into main?
+    if git branch --merged main 2>/dev/null | grep -qw "$wt_branch"; then
+      should_remove=true
+    fi
+
+    # Check 2: Does the remote tracking branch still exist?
+    # (GitHub deletes branches after squash-merge by default)
+    if [[ "$should_remove" == false ]] && ! git rev-parse --verify "refs/remotes/origin/$wt_branch" &>/dev/null; then
+      should_remove=true
+    fi
+
+    if [[ "$should_remove" == true && -n "${wt_path:-}" && -n "${wt_branch:-}" ]]; then
+      TO_REMOVE_PATHS+=("$wt_path")
+      TO_REMOVE_BRANCHES+=("$wt_branch")
+    fi
+
+    wt_path=""
+    wt_branch=""
+  fi
+done < <(git worktree list --porcelain; echo "")
+
+# Nothing to clean
+if [[ ${#TO_REMOVE_PATHS[@]} -eq 0 ]]; then
+  # Only print if running interactively (not from a hook with no removals)
+  if [[ "$FORCE" == false ]]; then
+    echo "No merged worktrees to clean up."
+  fi
+  exit 0
+fi
+
+echo ""
+echo "Merged worktrees detected:"
+for i in "${!TO_REMOVE_PATHS[@]}"; do
+  echo "  ${TO_REMOVE_BRANCHES[$i]}  →  ${TO_REMOVE_PATHS[$i]}"
+done
+echo ""
+
+if [[ "$FORCE" == false ]]; then
+  read -rp "Remove all listed worktrees and branches? [y/N] " answer
+  if [[ ! "$answer" =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+for i in "${!TO_REMOVE_PATHS[@]}"; do
+  wt_path="${TO_REMOVE_PATHS[$i]}"
+  wt_branch="${TO_REMOVE_BRANCHES[$i]}"
+
+  echo "Removing worktree: $wt_path ($wt_branch)"
+
+  # Remove the worktree directory
+  git worktree remove "$wt_path" --force 2>/dev/null || {
+    echo "  ⚠ Could not remove worktree at $wt_path — removing directory manually"
+    rm -rf "$wt_path"
+    git worktree prune
+  }
+
+  # Delete the local branch
+  git branch -D "$wt_branch" 2>/dev/null && echo "  Deleted branch $wt_branch" || echo "  ⚠ Branch $wt_branch already gone"
+done
+
+echo ""
+echo "Done. Cleaned up ${#TO_REMOVE_PATHS[@]} worktree(s)."


### PR DESCRIPTION
## Summary

Automatically clean up git worktrees after their branches are merged via pull request.

## What's included

- **`scripts/cleanup-merged-worktrees.sh`** — Detects worktrees whose branches are merged into `main` or whose remote tracking branch was deleted (e.g., after a squash-merge on GitHub). Removes the worktree directory and local branch. Supports interactive (default) and `--force` (non-interactive) modes.

- **`.husky/post-merge`** — Runs the cleanup script in `--force` mode after every `git pull origin main`, so merged worktrees are removed automatically.

- **`package.json`** — Adds a `worktree:cleanup` script for convenient manual runs (`bun run worktree:cleanup`).

- **Updated git-worktree skill docs** — Reflects the new automated cleanup workflow.

## How it works

1. After a PR is merged on GitHub, you run `git pull origin main` from the main checkout.
2. The `post-merge` hook fires and runs `cleanup-merged-worktrees.sh --force`.
3. The script runs `git fetch --prune`, iterates worktrees via `git worktree list --porcelain`, and checks each branch:
   - Is it merged into `main`?
   - Has its remote tracking branch been deleted?
4. Matching worktrees are removed along with their local branches.

## Manual usage

```bash
# Interactive (confirms before removing)
bun run worktree:cleanup

# Non-interactive
bash scripts/cleanup-merged-worktrees.sh --force
```