### PR TITLE
Fix/squash merge cleanup

### DIFF
--- a/.github/skills/git-worktree/SKILL.md
+++ b/.github/skills/git-worktree/SKILL.md
@@ -89,9 +89,18 @@ git pull origin main
 ```
 
 The `post-merge` husky hook runs `scripts/cleanup-merged-worktrees.sh --force`,
-which detects worktrees whose branches are merged into main or whose remote
-tracking branch was deleted (e.g., after a squash-merge on GitHub) and removes
-them along with the local branch.
+which detects worktrees whose branches should be removed using three checks:
+
+1. **Branch merged into main** — `git branch --merged` (normal merge / fast-forward).
+2. **Remote branch deleted** — upstream ref is gone after `git fetch --prune` (GitHub auto-delete or the `cleanup-branches` workflow).
+3. **PR squash-merged** — `gh pr list --state merged` finds a merged PR for the branch head (handles squash-merges where the original commits aren't ancestors of main).
+
+The script removes the worktree directory, deletes the local branch, and also
+deletes the remote branch if it still exists.
+
+A **GitHub Actions workflow** (`.github/workflows/cleanup-branches.yml`) also
+runs on every merged PR to delete the head branch server-side, ensuring Check 2
+works immediately on the next `git pull`.
 
 You can also run cleanup manually at any time:
 

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -1,0 +1,50 @@
+name: cleanup-branches
+
+# Delete the head branch after a PR is merged.
+# This is a safety net for when the GitHub repo setting
+# "Automatically delete head branches" is not enabled.
+# Once the remote branch is gone, the local post-merge hook
+# (via scripts/cleanup-merged-worktrees.sh) will detect the
+# missing upstream and clean up the worktree + local branch
+# on the next `git pull`.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete head branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Don't delete main or protected branches
+            if (branch === 'main' || branch === 'master') {
+              console.log(`Skipping deletion of protected branch: ${branch}`);
+              return;
+            }
+
+            try {
+              await github.rest.git.deleteRef({
+                owner,
+                repo,
+                ref: `heads/${branch}`,
+              });
+              console.log(`Deleted branch: ${branch}`);
+            } catch (error) {
+              if (error.status === 422) {
+                console.log(`Branch already deleted: ${branch}`);
+              } else {
+                throw error;
+              }
+            }

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,23 @@
 #!/usr/bin/env sh
 
 # Block direct pushes to main. All changes must go through a pull request.
+# Allow branch deletion (e.g., `git push origin --delete <branch>`) from any branch.
+
+# Detect if this is a delete-only push by reading the push info from stdin.
+# git sends lines of: <local ref> <local sha> <remote ref> <remote sha>
+# A delete has local ref = "(delete)" and local sha = all zeros.
+is_delete_only=true
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [ "$local_ref" != "(delete)" ]; then
+    is_delete_only=false
+    break
+  fi
+done
+
+if [ "$is_delete_only" = true ]; then
+  exit 0
+fi
+
 branch="$(git rev-parse --abbrev-ref HEAD)"
 
 if [ "$branch" = "main" ]; then

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -2,8 +2,11 @@
 #
 # cleanup-merged-worktrees.sh
 #
-# Removes git worktrees whose branches have been merged into main
-# (or whose remote tracking branch no longer exists after a squash-merge).
+# Removes git worktrees whose branches have been merged into main.
+# Detects three cases:
+#   1. Branch is an ancestor of main (normal merge / fast-forward).
+#   2. Remote tracking branch was deleted (GitHub auto-delete after merge).
+#   3. Branch's PR was squash-merged on GitHub (detected via `gh` CLI).
 #
 # Usage:
 #   ./scripts/cleanup-merged-worktrees.sh          # interactive (confirms each removal)
@@ -67,6 +70,16 @@ fi
 # Prune remote tracking refs so deleted remote branches are detected
 git fetch --prune --quiet 2>/dev/null || true
 
+# Detect gh CLI and resolve repo slug for squash-merge detection (Check 3)
+HAS_GH=false
+GH_REPO=""
+if command -v gh &>/dev/null; then
+  GH_REPO="$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)"
+  if [[ -n "$GH_REPO" ]]; then
+    HAS_GH=true
+  fi
+fi
+
 # Collect worktrees to clean up
 declare -a TO_REMOVE_PATHS=()
 declare -a TO_REMOVE_BRANCHES=()
@@ -104,6 +117,17 @@ while IFS= read -r line; do
       # Resolve "$wt_branch@{upstream}" to its full ref name; ignore errors if no upstream.
       upstream_ref="$(git rev-parse --abbrev-ref "${wt_branch}@{upstream}" 2>/dev/null || true)"
       if [[ -n "$upstream_ref" ]] && ! git rev-parse --verify "$upstream_ref" &>/dev/null; then
+        should_remove=true
+      fi
+    fi
+
+    # Check 3: Was the branch's PR squash-merged on GitHub?
+    # Squash-merges rewrite history so `git branch --merged` won't detect them,
+    # and the remote branch may still exist if auto-delete is disabled.
+    # Uses `gh` CLI if available to query closed+merged PRs for the branch.
+    if [[ "$should_remove" == false && "$HAS_GH" == true ]]; then
+      pr_state="$(gh pr list --repo "$GH_REPO" --head "$wt_branch" --state merged --json number --jq 'length' 2>/dev/null || echo "0")"
+      if [[ "$pr_state" -gt 0 ]]; then
         should_remove=true
       fi
     fi
@@ -158,6 +182,11 @@ for i in "${!TO_REMOVE_PATHS[@]}"; do
 
   # Delete the local branch
   git branch -D "$wt_branch" 2>/dev/null && echo "  Deleted branch $wt_branch" || echo "  ⚠ Branch $wt_branch already gone"
+
+  # Delete the remote branch if it still exists
+  if git rev-parse --verify "refs/remotes/origin/$wt_branch" &>/dev/null; then
+    git push origin --delete "$wt_branch" 2>/dev/null && echo "  Deleted remote branch origin/$wt_branch" || echo "  ⚠ Could not delete remote branch origin/$wt_branch"
+  fi
 done
 
 echo ""


### PR DESCRIPTION
This pull request introduces improvements to the workflow and automation around cleaning up merged branches and their associated worktrees. The changes ensure that branches are reliably deleted both locally and remotely after merges—including squash merges—and that worktree cleanup is robust and automatic. The updates also clarify documentation and add safeguards for branch deletion.

**Branch and worktree cleanup automation:**

* Added `.github/workflows/cleanup-branches.yml` workflow to automatically delete the head branch on GitHub after a PR is merged, ensuring remote branches are removed even if the repo setting is not enabled. Protected branches like `main` and `master` are not deleted.
* Updated `scripts/cleanup-merged-worktrees.sh` to detect three cases for worktree removal: branch merged into main, remote branch deleted, and PR squash-merged (using the `gh` CLI to check for merged PRs). The script now also deletes the remote branch if it still exists. [[1]](diffhunk://#diff-d468f048d711dcacb640c1fa687b314632f827dd7dc74551716f89b437093489L5-R9) [[2]](diffhunk://#diff-d468f048d711dcacb640c1fa687b314632f827dd7dc74551716f89b437093489R73-R82) [[3]](diffhunk://#diff-d468f048d711dcacb640c1fa687b314632f827dd7dc74551716f89b437093489R124-R134) [[4]](diffhunk://#diff-d468f048d711dcacb640c1fa687b314632f827dd7dc74551716f89b437093489R185-R189)

**Documentation updates:**

* Improved `.github/skills/git-worktree/SKILL.md` to explain the three checks for worktree removal and document the new GitHub Actions workflow for deleting remote branches after PR merges.

**Safeguards and usability improvements:**

* Modified `.husky/pre-push` to allow branch deletion pushes from any branch, and to block direct pushes to `main` except for delete-only pushes.