### PR TITLE
chore(ai): add core workflow skills

### DIFF
--- a/.github/agents/expo-dependency-auditor.agent.md
+++ b/.github/agents/expo-dependency-auditor.agent.md
@@ -1,0 +1,51 @@
+---
+description: 'Audits Expo dependency compatibility without editing files. Use when running Expo Doctor, upgrading packages, checking lockfile risk, or deciding whether a native rebuild is required.'
+name: 'Expo Dependency Auditor'
+tools: ['search', 'read/problems', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/runInTerminal', 'web/fetch', 'web/githubRepo']
+---
+
+# Expo Dependency Auditor
+
+You are a read-only Expo dependency auditor. Run and interpret compatibility checks, identify risky dependency changes, and report the safest fix path; do not edit files.
+
+## When to use
+
+- `expo-doctor` reports SDK compatibility, duplicate native module, or React Native Directory issues.
+- Dependency updates touch Expo, React, React Native, Reanimated, Skia, Worklets, or native modules.
+- The repo needs `expo install --check` results interpreted.
+- A change may affect `@expo/fingerprint`, `runtimeVersion`, EAS Update, or EAS Build behavior.
+
+## Investigation workflow
+
+1. Inspect `package.json`, `bun.lock`, `app.json`, `eas.json`, and Expo-related workflows.
+2. Run `bunx expo install --check` and `bunx expo-doctor@latest` when dependencies are installed.
+3. Classify each warning as blocker, should-fix, monitor, or expected exclusion.
+4. Check for manual version bumps to `expo`, `react`, `react-native`, or native modules that bypass Expo recommendations.
+5. Inspect `overrides`, especially `@expo/fingerprint`, and decide whether the override still appears intentional.
+6. Determine release impact: OTA-safe JavaScript/UI change or native build required due to native dependency/config changes.
+
+## Checks
+
+- Expo SDK packages are aligned through `expo install`, not broad ecosystem upgrades.
+- No duplicate React, React Native, or native Expo modules appear in the installed graph.
+- `expo.doctor.reactNativeDirectoryCheck.exclude` entries remain intentional and narrow.
+- `runtimeVersion` still uses the app version policy.
+- CI workflows still run Expo Doctor and fingerprint-based OTA/native routing.
+
+## Report format
+
+```md
+## Dependency status
+- Expo SDK:
+- Doctor result:
+- Install check result:
+
+## Findings
+[SEVERITY] file:line - finding
+Fix: concrete action
+
+## Release impact
+- OTA eligible:
+- Native build required:
+- Workflow/profile to use:
+```

--- a/.github/agents/healthkit-data-pipeline-auditor.agent.md
+++ b/.github/agents/healthkit-data-pipeline-auditor.agent.md
@@ -1,0 +1,50 @@
+---
+description: 'Audits the iOS HealthKit to app data pipeline without editing files. Use when HealthKit metrics look wrong, demo data appears unexpectedly, or daily health snapshots are not syncing.'
+name: 'HealthKit Data Pipeline Auditor'
+tools: ['search', 'read/problems', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/runInTerminal', 'web/fetch', 'web/githubRepo']
+---
+
+# HealthKit Data Pipeline Auditor
+
+You are a read-only auditor for the HealthKit data path. Diagnose the active data path, identify mismatches, and report concrete fixes; do not edit files.
+
+## When to use
+
+- Health metrics show zero, stale, or obviously fake values.
+- Web or Android previews may be showing `generateMockData` instead of real HealthKit data.
+- The app should persist or read from `daily_health_snapshots`.
+- HealthKit authorization, `READ_PERMISSIONS`, or Info.plist usage strings may be incomplete.
+
+## Investigation workflow
+
+1. Identify platform mode: confirm whether the app path is real HealthKit (`Platform.OS === 'ios'`) or demo mode.
+2. Trace permissions: compare `READ_PERMISSIONS` and write permissions in `src/lib/healthkit.ts` with the HealthKit config plugin entries in `app.json`.
+3. Trace metric collection: inspect each HealthKit query function, quantity/category/workout identifiers, date windows, units, and fallback values.
+4. Trace hook state: inspect `src/hooks/useHealthKit.ts` for authorization flow, `isDemoMode`, refresh behavior, and `generateMockData` behavior.
+5. Trace persistence: compare `daily_health_snapshots` migration columns with `dailyHealthSnapshotSchema` and any store or hook that upserts snapshots.
+6. Classify failures as blocker, high, medium, or low based on whether they break iOS collection, silently show demo data, or only affect a secondary metric.
+
+## Checks
+
+- HealthKit-only imports are platform-gated and do not break web.
+- Query identifiers match the `@kingstinct/react-native-healthkit` API and Apple HealthKit identifiers.
+- Date windows match the intended daily aggregation.
+- Demo mode is explicit in UI or diagnostics when HealthKit is unavailable.
+- `daily_health_snapshots` field names are mapped correctly between snake_case SQL and camelCase TypeScript.
+- Errors are surfaced through existing app patterns and not swallowed into success-shaped data.
+
+## Report format
+
+```md
+## Active path
+- Platform/data path:
+- Authorization state:
+
+## Findings
+[SEVERITY] file:line - finding
+Fix: concrete action
+
+## Verification
+- Commands or simulator/web checks to run
+- Metrics or rows to inspect
+```

--- a/.github/agents/supabase-schema-reviewer.agent.md
+++ b/.github/agents/supabase-schema-reviewer.agent.md
@@ -1,0 +1,51 @@
+---
+description: 'Reviews Supabase migrations, generated database types, validators, and store mappings without editing files. Use when adding tables, changing RLS, or checking schema safety.'
+name: 'Supabase Schema Reviewer'
+tools: ['search', 'read/problems', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/runInTerminal', 'web/fetch', 'web/githubRepo']
+---
+
+# Supabase Schema Reviewer
+
+You are a read-only schema reviewer. Audit schema changes across SQL, generated types, validators, and app mappings; report issues with precise fixes and do not edit files.
+
+## When to use
+
+- A migration is added or changed under `supabase/migrations/`.
+- RLS policies are added, loosened, or removed.
+- `src/lib/database.types.ts` or `src/lib/validators.ts` may be out of sync.
+- A Zustand store maps Supabase snake_case rows into camelCase app models.
+
+## Investigation workflow
+
+1. Identify changed migrations and classify them as additive, destructive, or policy-only.
+2. Review SQL naming, constraints, defaults, indexes, triggers, and `updated_at` behavior.
+3. Review RLS: confirm `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`, policy coverage, and whether policies intentionally allow anonymous access or require `auth.uid()`.
+4. Compare migration columns against `database.types.ts` to confirm `bun run generate-types` was run.
+5. Compare database shapes against `validators.ts`, checking required/nullable fields and Zod v4 non-deprecated APIs.
+6. Trace store mappings for snake_case to camelCase conversion and nullability handling.
+
+## Checks
+
+- No service-role key or privileged Supabase client is used in client code.
+- RLS policies match the app's auth model and are not broader than intended.
+- Destructive migrations are called out as breaking changes.
+- Validator schemas are not looser than the database for required fields.
+- Generated types, validators, and stores agree on names and nullability.
+
+## Report format
+
+```md
+## Schema surface
+- Migrations reviewed:
+- App schemas reviewed:
+
+## Findings
+[SEVERITY] file:line - finding
+Fix: concrete action
+
+## Follow-up validation
+- bun run generate-types
+- bun run lint
+- bun run typecheck
+- Targeted tests or db probes
+```

--- a/.github/skills/eas-release/SKILL.md
+++ b/.github/skills/eas-release/SKILL.md
@@ -44,4 +44,4 @@ Verify the release path matches the change type and that required workflow secre
 - Never ship native dependency or config-plugin changes with OTA only.
 - Do not push directly to `main`; releases must come from reviewed PRs.
 - Do not commit EAS, Apple, Google, or Supabase secrets.
-- Keep release automation aligned with Bun, Expo SDK 54, and the existing GitHub workflow files.
+- Keep release automation aligned with Bun, Expo SDK 55, and the existing GitHub workflow files.

--- a/.github/skills/eas-release/SKILL.md
+++ b/.github/skills/eas-release/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: eas-release
+description: 'Guides safe Expo EAS releases for this app, choosing OTA updates versus native builds and GitHub workflows. Use when preparing an Expo release, publishing EAS Update, running build.yml, or checking runtimeVersion safety.'
+---
+
+# EAS Release
+
+## Quick start
+
+For JavaScript, UI, or asset-only changes, keep `app.json` on `runtimeVersion` policy `appVersion`, validate locally, then publish through `.github/workflows/update.yml` or run:
+
+```bash
+eas update --auto
+```
+
+For native changes, skip OTA and trigger the production build workflow:
+
+```bash
+gh workflow run build.yml --ref main -f platform=ios -f profile=production
+```
+
+## Workflow
+
+1. Classify the change: JS/assets can use EAS Update; native dependencies, config plugins, `app.json` native fields, or generated native projects require EAS Build.
+2. Confirm `runtimeVersion` still prevents incompatible OTA updates; this repo uses the `appVersion` policy.
+3. For OTA, merge through PR to `main` and let `update.yml` publish after the native fingerprint check, or run `eas update --auto` only with a valid `EXPO_TOKEN`.
+4. For native releases, use `build.yml` with `profile=production`; prioritize iOS, keep web unaffected, and treat Android as best-effort.
+5. Monitor EAS build/update output and roll back or republish if production health regresses.
+
+## Validation
+
+Run before release changes merge:
+
+```bash
+bun run lint
+bun run typecheck
+bunx expo-doctor@latest
+```
+
+Verify the release path matches the change type and that required workflow secrets are present without printing token values.
+
+## Guardrails
+
+- Never ship native dependency or config-plugin changes with OTA only.
+- Do not push directly to `main`; releases must come from reviewed PRs.
+- Do not commit EAS, Apple, Google, or Supabase secrets.
+- Keep release automation aligned with Bun, Expo SDK 54, and the existing GitHub workflow files.

--- a/.github/skills/expo-sdk-upgrade/SKILL.md
+++ b/.github/skills/expo-sdk-upgrade/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: expo-sdk-upgrade
+description: 'Guides safe, incremental Expo SDK upgrades for this Bun/Expo project. Use when upgrading Expo SDK versions, aligning Expo dependencies, or fixing SDK compatibility issues reported by Expo Doctor.'
+---
+
+# Expo SDK Upgrade
+
+## Quick start
+
+```bash
+bunx expo install expo@~<target-sdk-version>
+bunx expo install --fix
+bunx expo-doctor@latest
+bun run lint
+bun run typecheck
+```
+
+## Workflow
+
+1. Confirm the current SDK and target SDK from `package.json`; upgrade one SDK version at a time unless the user explicitly accepts the migration risk.
+2. Create work in a sibling git worktree and keep the main checkout on `main`.
+3. Update `expo` to the target SDK range, then run `bunx expo install --fix` so React, React Native, and Expo modules stay in the Expo-supported matrix.
+4. Review the official Expo SDK release notes for required manual migration steps, removed APIs, config plugin changes, and native rebuild requirements.
+5. Run `bunx expo-doctor@latest` and resolve all warnings that affect SDK compatibility, duplicate native modules, or unsupported packages.
+6. If native files, config plugins, or native dependencies changed, treat the result as requiring a new binary build instead of an OTA-only EAS Update.
+
+## Validation
+
+Run these before committing:
+
+```bash
+bunx expo install --check
+bunx expo-doctor@latest
+bun run lint
+bun run typecheck
+bunx jest --runInBand
+```
+
+If `expo-doctor` reports duplicate native modules after an update, delete `node_modules`, run `bun install`, and rerun the doctor check before changing dependency ranges by hand.
+
+## Guardrails
+
+- Do not manually bump `react` or `react-native` independently from Expo recommendations.
+- Do not run broad upgrade tools such as `ncu -u` for SDK work.
+- Keep package manager commands on Bun (`bun install`, `bun add`, `bunx`).
+- Check for deprecated APIs in files touched by migration steps.
+- Use a conventional commit such as `chore(deps): upgrade Expo SDK`.

--- a/.github/skills/new-screen-route/SKILL.md
+++ b/.github/skills/new-screen-route/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: new-screen-route
+description: 'Adds Expo Router screens that match this app’s tab, stack, modal, and typed route conventions. Use when creating a new screen, adding a route under src/app, editing (tabs), or wiring navigation in _layout.tsx.'
+---
+
+# New Screen Route
+
+## Quick start
+
+Add screens under `src/app/`. Put primary navigation in `src/app/(tabs)/<name>.tsx`; put modal or stack screens beside the root `_layout.tsx`, such as `src/app/weight.tsx`.
+
+Register route options in the nearest `_layout.tsx` and navigate with expo-router typed routes rather than ad-hoc string paths.
+
+## Workflow
+
+1. Choose the route shape: `(tabs)` for core tabs, `[id].tsx` for dynamic details, or a root stack/modal file for focused flows.
+2. Create a small screen component using React Native primitives, project design tokens, and `@/*` imports.
+3. Register stack or tab options in `src/app/_layout.tsx` or `src/app/(tabs)/_layout.tsx`; keep headers and presentation consistent with nearby screens.
+4. Link to the screen with `Link`, `router.push`, or `router.navigate` using typed routes, including explicit params for dynamic paths.
+5. Keep data access in stores/hooks; screens should compose UI and call existing domain APIs.
+
+## Validation
+
+Run:
+
+```bash
+bun run lint
+bun run typecheck
+bunx jest --runInBand
+```
+
+Also smoke-test the route on iOS simulator and web when navigation, layout, or platform behavior changes.
+
+## Guardrails
+
+- Do not duplicate route names across groups unless Expo Router semantics require it.
+- Keep HealthKit or native-only UI hidden or gracefully degraded off iOS.
+- Prefer platform-specific files for major divergence; use small inline gates only for simple layout differences.
+- Do not add Android-only navigation or native dependencies for a screen unless they also serve iOS or web.

--- a/.github/skills/new-zustand-store/SKILL.md
+++ b/.github/skills/new-zustand-store/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: new-zustand-store
+description: 'Creates repo-consistent Zustand stores with persistence, selectors, initialization, and Supabase-aware actions. Use when adding a new domain store or extending state management in src/stores.'
+---
+
+# New Zustand Store
+
+## Quick start
+
+Create `src/stores/<Domain>Store.ts` and expose a small public interface:
+
+```ts
+export interface DomainState {
+  items: DomainItem[]
+  isLoading: boolean
+  error: string | null
+  initialize: () => Promise<void>
+}
+```
+
+Use `create<State>()`, `persist`, `createJSONStorage(() => AsyncStorage)`, `partialize`, and selector hooks with `useShallow`.
+
+## Workflow
+
+1. Define the domain state interface first: persisted data fields, ephemeral UI fields, and action signatures.
+2. Keep business logic in the store and UI logic in components; do not put derived values into raw store state.
+3. Use `create<State>()(persist(...))` for stores that need persistence, with `partialize` to exclude loading flags, errors, and initialization flags.
+4. For Supabase-backed stores, validate inputs with existing Zod schemas, map snake_case rows to camelCase models explicitly, and surface errors through the store's existing error pattern.
+5. Export focused selector hooks or a convenience hook using `useShallow` so components do not rerender for unrelated state changes.
+6. Initialize stores from screens or layouts with a guarded `useEffect` that calls `initialize()` once.
+
+## Validation
+
+For each behavior, add or update tests through the public store hook/API rather than internal implementation details.
+
+Run:
+
+```bash
+bun run lint
+bun run typecheck
+bunx jest --runInBand
+```
+
+## Guardrails
+
+- Never mutate arrays or objects from Zustand state directly; use immutable updates.
+- Do not persist volatile fields such as `isLoading`, `error`, or in-flight promises.
+- Do not use `any` for store state, actions, or Supabase rows.
+- Prefer Zod v4 top-level schemas such as `z.uuid()` and `z.iso.datetime()` when adding validators.
+- Keep store modules deep: small component-facing API, deeper implementation inside actions.

--- a/.github/skills/platform-gate/SKILL.md
+++ b/.github/skills/platform-gate/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: platform-gate
+description: 'Applies repo-specific iOS, web, and Android platform gates with deterministic fallbacks. Use when touching HealthKit, native modules, Platform.OS checks, Platform.select values, or mock data generation.'
+---
+
+# Platform Gate
+
+## Quick start
+
+Gate iOS-only features explicitly and provide deterministic fallback data elsewhere:
+
+```ts
+const enabled = Platform.OS === 'ios'
+const padding = Platform.select({ ios: 20, web: 16, default: 14 })
+```
+
+Use existing mock adapters where possible; for new domains, add a deterministic `generateMockData` helper and test it.
+
+## Workflow
+
+1. Identify the platform dependency: HealthKit and native modules are iOS-first; web must not crash; Android is best-effort.
+2. Use `Platform.select` for style, spacing, and config values instead of scattered branching.
+3. Use `Platform.OS === 'ios'` before requesting native permissions, rendering HealthKit-only UI, or calling iOS-only adapters.
+4. Provide a deterministic fallback adapter or `generateMockData` path for web, tests, and unsupported devices.
+5. For large differences, split files with `.ios.tsx`, `.web.tsx`, or `.native.tsx` rather than growing conditional components.
+
+## Validation
+
+Run:
+
+```bash
+bun run lint
+bun run typecheck
+bunx jest --runInBand
+```
+
+For UI changes, smoke-test iOS and web. Add tests that assert unsupported platforms use the fallback path and do not call native-only APIs.
+
+## Guardrails
+
+- Never import or execute unsupported native APIs on web without a safe module boundary.
+- Do not show HealthKit setup controls unless the iOS adapter is available.
+- Keep mock data deterministic; avoid `Math.random()` for fallback snapshots.
+- Prefer iOS and web correctness over Android parity, but avoid knowingly breaking Android.

--- a/.github/skills/supabase-migration/SKILL.md
+++ b/.github/skills/supabase-migration/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: supabase-migration
+description: 'Guides safe Supabase schema changes across SQL migrations, generated DB types, Zod validators, and stores. Use when adding tables, changing columns, writing RLS policies, or regenerating database types.'
+---
+
+# Supabase Migration
+
+## Quick start
+
+```bash
+touch supabase/migrations/$(date +%Y%m%d%H%M%S)_<description>.sql
+bun run db:migrate
+bun run generate-types
+bun run db:debug
+```
+
+## Workflow
+
+1. Create one timestamped SQL file in `supabase/migrations/` with snake_case table and column names.
+2. Add `created_at` and `updated_at` defaults when the table represents user-owned mutable data.
+3. Enable RLS and define policies for the operations the app actually needs; policies should use `auth.uid()` for user ownership.
+4. Apply the migration, then run `bun run generate-types` so `src/lib/database.types.ts` matches the database.
+5. Update `src/lib/validators.ts` with matching Zod schemas and derive TypeScript types with `z.infer<>`.
+6. Update stores to map database snake_case rows to app camelCase models explicitly.
+7. Run `bun run db:debug` when environment variables are available to confirm Supabase auth, REST, and SDK access.
+
+## Validation
+
+Run:
+
+```bash
+bun run lint
+bun run typecheck
+bunx jest --runInBand
+```
+
+Review the migration against the generated types, validators, and store mappings before committing.
+
+## Guardrails
+
+- Never expose service-role keys to the client app.
+- Do not bypass RLS from client-side code.
+- Do not hand-edit generated database types except as a temporary diagnostic step that is reverted before commit.
+- Do not leave validators looser than the database schema for required fields.
+- Prefer additive migrations; flag dropped or renamed columns as breaking changes in the PR.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:watch": "bunx jest --watch",
     "lint": "bunx eslint .",
     "typecheck": "tsc --noEmit",
+    "validate:ai-artifacts": "bun run scripts/validate-ai-artifacts.ts",
     "db:debug": "bun run scripts/debug-db.ts",
     "generate-types": "supabase gen types typescript --project-id \"$EXPO_PUBLIC_SUPABASE_PROJECT_ID\" --schema public > src/lib/database.types.ts",
     "db:migrate": "supabase db push",

--- a/scripts/validate-ai-artifacts.ts
+++ b/scripts/validate-ai-artifacts.ts
@@ -46,7 +46,30 @@ const requiredSkills: RequiredSkill[] = [
   },
 ]
 
-const requiredAgents: RequiredAgent[] = []
+const requiredAgents: RequiredAgent[] = [
+  {
+    file: 'healthkit-data-pipeline-auditor.agent.md',
+    name: 'HealthKit Data Pipeline Auditor',
+    readOnly: true,
+    requiredTerms: [
+      'daily_health_snapshots',
+      'generateMockData',
+      'READ_PERMISSIONS',
+    ],
+  },
+  {
+    file: 'supabase-schema-reviewer.agent.md',
+    name: 'Supabase Schema Reviewer',
+    readOnly: true,
+    requiredTerms: ['RLS', 'database.types.ts', 'validators.ts'],
+  },
+  {
+    file: 'expo-dependency-auditor.agent.md',
+    name: 'Expo Dependency Auditor',
+    readOnly: true,
+    requiredTerms: ['expo-doctor', 'expo install --check', '@expo/fingerprint'],
+  },
+]
 
 const deprecatedToolNames = new Set([
   'codebase',

--- a/scripts/validate-ai-artifacts.ts
+++ b/scripts/validate-ai-artifacts.ts
@@ -28,6 +28,22 @@ const requiredSkills: RequiredSkill[] = [
     name: 'supabase-migration',
     requiredTerms: ['RLS', 'generate-types', 'validators'],
   },
+  {
+    name: 'eas-release',
+    requiredTerms: ['eas update --auto', 'build.yml', 'runtimeVersion'],
+  },
+  {
+    name: 'new-screen-route',
+    requiredTerms: ['(tabs)', '_layout.tsx', 'typed routes'],
+  },
+  {
+    name: 'platform-gate',
+    requiredTerms: [
+      "Platform.OS === 'ios'",
+      'Platform.select',
+      'generateMockData',
+    ],
+  },
 ]
 
 const requiredAgents: RequiredAgent[] = []

--- a/scripts/validate-ai-artifacts.ts
+++ b/scripts/validate-ai-artifacts.ts
@@ -1,0 +1,199 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+type RequiredSkill = {
+  name: string
+  requiredTerms: string[]
+}
+
+type RequiredAgent = {
+  file: string
+  name: string
+  readOnly: boolean
+  requiredTerms: string[]
+}
+
+const root = process.cwd()
+
+const requiredSkills: RequiredSkill[] = [
+  {
+    name: 'expo-sdk-upgrade',
+    requiredTerms: ['expo install --fix', 'expo-doctor', 'release notes'],
+  },
+  {
+    name: 'new-zustand-store',
+    requiredTerms: ['create<State>()', 'partialize', 'useShallow'],
+  },
+  {
+    name: 'supabase-migration',
+    requiredTerms: ['RLS', 'generate-types', 'validators'],
+  },
+]
+
+const requiredAgents: RequiredAgent[] = []
+
+const deprecatedToolNames = new Set([
+  'codebase',
+  'changes',
+  'extensions',
+  'fetch',
+  'findTestFiles',
+  'githubRepo',
+  'new',
+  'openSimpleBrowser',
+  'problems',
+  'runCommands',
+  'runTasks',
+  'runTests',
+  'searchResults',
+  'terminalCommand',
+  'terminalLastCommand',
+  'terminalSelection',
+  'testFailure',
+  'usages',
+  'vscodeAPI',
+])
+
+const allowedUnnamespacedTools = new Set(['search'])
+const editTools = new Set(['edit/editFiles'])
+
+function fail(message: string): never {
+  throw new Error(message)
+}
+
+function readArtifact(path: string) {
+  const fullPath = join(root, path)
+
+  if (!existsSync(fullPath)) {
+    fail(`Missing artifact: ${path}`)
+  }
+
+  return readFileSync(fullPath, 'utf8')
+}
+
+function parseFrontmatter(markdown: string, path: string) {
+  const match = /^---\n([\s\S]*?)\n---\n/.exec(markdown)
+
+  if (!match) {
+    fail(`${path}: missing YAML frontmatter`)
+  }
+
+  const frontmatter: Record<string, string> = {}
+
+  for (const line of match[1].split('\n')) {
+    const separatorIndex = line.indexOf(':')
+
+    if (separatorIndex === -1) {
+      continue
+    }
+
+    const key = line.slice(0, separatorIndex).trim()
+    const value = line.slice(separatorIndex + 1).trim()
+    frontmatter[key] = value.replace(/^['"]|['"]$/g, '')
+  }
+
+  return frontmatter
+}
+
+function parseInlineArray(value: string | undefined) {
+  if (!value) {
+    return []
+  }
+
+  const match = /^\[(.*)\]$/.exec(value.trim())
+
+  if (!match) {
+    return []
+  }
+
+  return match[1]
+    .split(',')
+    .map((item) => item.trim().replace(/^['"]|['"]$/g, ''))
+    .filter(Boolean)
+}
+
+function assertIncludes(markdown: string, path: string, term: string) {
+  if (!markdown.includes(term)) {
+    fail(`${path}: expected content to include "${term}"`)
+  }
+}
+
+function validateSkill(skill: RequiredSkill) {
+  const path = `.github/skills/${skill.name}/SKILL.md`
+  const markdown = readArtifact(path)
+  const frontmatter = parseFrontmatter(markdown, path)
+
+  if (frontmatter.name !== skill.name) {
+    fail(`${path}: frontmatter name must be "${skill.name}"`)
+  }
+
+  if (!frontmatter.description) {
+    fail(`${path}: missing frontmatter description`)
+  }
+
+  if (frontmatter.description.length > 1024) {
+    fail(`${path}: description must be 1024 characters or fewer`)
+  }
+
+  assertIncludes(frontmatter.description, path, 'Use when')
+  assertIncludes(markdown, path, '## Quick start')
+  assertIncludes(markdown, path, '## Workflow')
+  assertIncludes(markdown, path, '## Validation')
+
+  for (const term of skill.requiredTerms) {
+    assertIncludes(markdown, path, term)
+  }
+}
+
+function validateAgent(agent: RequiredAgent) {
+  const path = `.github/agents/${agent.file}`
+  const markdown = readArtifact(path)
+  const frontmatter = parseFrontmatter(markdown, path)
+  const tools = parseInlineArray(frontmatter.tools)
+
+  if (frontmatter.name !== agent.name) {
+    fail(`${path}: frontmatter name must be "${agent.name}"`)
+  }
+
+  if (!frontmatter.description) {
+    fail(`${path}: missing frontmatter description`)
+  }
+
+  if (tools.length === 0) {
+    fail(`${path}: read-only diagnostic agents must declare tools`)
+  }
+
+  for (const tool of tools) {
+    if (deprecatedToolNames.has(tool)) {
+      fail(`${path}: deprecated un-namespaced tool "${tool}"`)
+    }
+
+    if (!tool.includes('/') && !allowedUnnamespacedTools.has(tool)) {
+      fail(`${path}: tool "${tool}" must be namespaced`)
+    }
+
+    if (agent.readOnly && editTools.has(tool)) {
+      fail(`${path}: read-only agent must not include edit tool "${tool}"`)
+    }
+  }
+
+  assertIncludes(markdown, path, '## When to use')
+  assertIncludes(markdown, path, '## Investigation workflow')
+  assertIncludes(markdown, path, '## Report format')
+
+  for (const term of agent.requiredTerms) {
+    assertIncludes(markdown, path, term)
+  }
+}
+
+for (const skill of requiredSkills) {
+  validateSkill(skill)
+}
+
+for (const agent of requiredAgents) {
+  validateAgent(agent)
+}
+
+console.log(
+  `Validated ${requiredSkills.length} skills and ${requiredAgents.length} custom agents.`,
+)


### PR DESCRIPTION
## Summary
- add an AI artifact validator for repo skills and custom agents
- add Expo SDK upgrade, new Zustand store, and Supabase migration skills

## Validation
- bun run validate:ai-artifacts
- bun run lint
- bun run typecheck