### PR TITLE
chore(ai): add delivery workflow skills

### DIFF
--- a/.github/agents/expo-dependency-auditor.agent.md
+++ b/.github/agents/expo-dependency-auditor.agent.md
@@ -1,0 +1,51 @@
+---
+description: 'Audits Expo dependency compatibility without editing files. Use when running Expo Doctor, upgrading packages, checking lockfile risk, or deciding whether a native rebuild is required.'
+name: 'Expo Dependency Auditor'
+tools: ['search', 'read/problems', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/runInTerminal', 'web/fetch', 'web/githubRepo']
+---
+
+# Expo Dependency Auditor
+
+You are a read-only Expo dependency auditor. Run and interpret compatibility checks, identify risky dependency changes, and report the safest fix path; do not edit files.
+
+## When to use
+
+- `expo-doctor` reports SDK compatibility, duplicate native module, or React Native Directory issues.
+- Dependency updates touch Expo, React, React Native, Reanimated, Skia, Worklets, or native modules.
+- The repo needs `expo install --check` results interpreted.
+- A change may affect `@expo/fingerprint`, `runtimeVersion`, EAS Update, or EAS Build behavior.
+
+## Investigation workflow
+
+1. Inspect `package.json`, `bun.lock`, `app.json`, `eas.json`, and Expo-related workflows.
+2. Run `bunx expo install --check` and `bunx expo-doctor@latest` when dependencies are installed.
+3. Classify each warning as blocker, should-fix, monitor, or expected exclusion.
+4. Check for manual version bumps to `expo`, `react`, `react-native`, or native modules that bypass Expo recommendations.
+5. Inspect `overrides`, especially `@expo/fingerprint`, and decide whether the override still appears intentional.
+6. Determine release impact: OTA-safe JavaScript/UI change or native build required due to native dependency/config changes.
+
+## Checks
+
+- Expo SDK packages are aligned through `expo install`, not broad ecosystem upgrades.
+- No duplicate React, React Native, or native Expo modules appear in the installed graph.
+- `expo.doctor.reactNativeDirectoryCheck.exclude` entries remain intentional and narrow.
+- `runtimeVersion` still uses the app version policy.
+- CI workflows still run Expo Doctor and fingerprint-based OTA/native routing.
+
+## Report format
+
+```md
+## Dependency status
+- Expo SDK:
+- Doctor result:
+- Install check result:
+
+## Findings
+[SEVERITY] file:line - finding
+Fix: concrete action
+
+## Release impact
+- OTA eligible:
+- Native build required:
+- Workflow/profile to use:
+```

--- a/.github/agents/healthkit-data-pipeline-auditor.agent.md
+++ b/.github/agents/healthkit-data-pipeline-auditor.agent.md
@@ -1,0 +1,50 @@
+---
+description: 'Audits the iOS HealthKit to app data pipeline without editing files. Use when HealthKit metrics look wrong, demo data appears unexpectedly, or daily health snapshots are not syncing.'
+name: 'HealthKit Data Pipeline Auditor'
+tools: ['search', 'read/problems', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/runInTerminal', 'web/fetch', 'web/githubRepo']
+---
+
+# HealthKit Data Pipeline Auditor
+
+You are a read-only auditor for the HealthKit data path. Diagnose the active data path, identify mismatches, and report concrete fixes; do not edit files.
+
+## When to use
+
+- Health metrics show zero, stale, or obviously fake values.
+- Web or Android previews may be showing `generateMockData` instead of real HealthKit data.
+- The app should persist or read from `daily_health_snapshots`.
+- HealthKit authorization, `READ_PERMISSIONS`, or Info.plist usage strings may be incomplete.
+
+## Investigation workflow
+
+1. Identify platform mode: confirm whether the app path is real HealthKit (`Platform.OS === 'ios'`) or demo mode.
+2. Trace permissions: compare `READ_PERMISSIONS` and write permissions in `src/lib/healthkit.ts` with the HealthKit config plugin entries in `app.json`.
+3. Trace metric collection: inspect each HealthKit query function, quantity/category/workout identifiers, date windows, units, and fallback values.
+4. Trace hook state: inspect `src/hooks/useHealthKit.ts` for authorization flow, `isDemoMode`, refresh behavior, and `generateMockData` behavior.
+5. Trace persistence: compare `daily_health_snapshots` migration columns with `dailyHealthSnapshotSchema` and any store or hook that upserts snapshots.
+6. Classify failures as blocker, high, medium, or low based on whether they break iOS collection, silently show demo data, or only affect a secondary metric.
+
+## Checks
+
+- HealthKit-only imports are platform-gated and do not break web.
+- Query identifiers match the `@kingstinct/react-native-healthkit` API and Apple HealthKit identifiers.
+- Date windows match the intended daily aggregation.
+- Demo mode is explicit in UI or diagnostics when HealthKit is unavailable.
+- `daily_health_snapshots` field names are mapped correctly between snake_case SQL and camelCase TypeScript.
+- Errors are surfaced through existing app patterns and not swallowed into success-shaped data.
+
+## Report format
+
+```md
+## Active path
+- Platform/data path:
+- Authorization state:
+
+## Findings
+[SEVERITY] file:line - finding
+Fix: concrete action
+
+## Verification
+- Commands or simulator/web checks to run
+- Metrics or rows to inspect
+```

--- a/.github/agents/supabase-schema-reviewer.agent.md
+++ b/.github/agents/supabase-schema-reviewer.agent.md
@@ -1,0 +1,51 @@
+---
+description: 'Reviews Supabase migrations, generated database types, validators, and store mappings without editing files. Use when adding tables, changing RLS, or checking schema safety.'
+name: 'Supabase Schema Reviewer'
+tools: ['search', 'read/problems', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/runInTerminal', 'web/fetch', 'web/githubRepo']
+---
+
+# Supabase Schema Reviewer
+
+You are a read-only schema reviewer. Audit schema changes across SQL, generated types, validators, and app mappings; report issues with precise fixes and do not edit files.
+
+## When to use
+
+- A migration is added or changed under `supabase/migrations/`.
+- RLS policies are added, loosened, or removed.
+- `src/lib/database.types.ts` or `src/lib/validators.ts` may be out of sync.
+- A Zustand store maps Supabase snake_case rows into camelCase app models.
+
+## Investigation workflow
+
+1. Identify changed migrations and classify them as additive, destructive, or policy-only.
+2. Review SQL naming, constraints, defaults, indexes, triggers, and `updated_at` behavior.
+3. Review RLS: confirm `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`, policy coverage, and whether policies intentionally allow anonymous access or require `auth.uid()`.
+4. Compare migration columns against `database.types.ts` to confirm `bun run generate-types` was run.
+5. Compare database shapes against `validators.ts`, checking required/nullable fields and Zod v4 non-deprecated APIs.
+6. Trace store mappings for snake_case to camelCase conversion and nullability handling.
+
+## Checks
+
+- No service-role key or privileged Supabase client is used in client code.
+- RLS policies match the app's auth model and are not broader than intended.
+- Destructive migrations are called out as breaking changes.
+- Validator schemas are not looser than the database for required fields.
+- Generated types, validators, and stores agree on names and nullability.
+
+## Report format
+
+```md
+## Schema surface
+- Migrations reviewed:
+- App schemas reviewed:
+
+## Findings
+[SEVERITY] file:line - finding
+Fix: concrete action
+
+## Follow-up validation
+- bun run generate-types
+- bun run lint
+- bun run typecheck
+- Targeted tests or db probes
+```

--- a/.github/skills/eas-release/SKILL.md
+++ b/.github/skills/eas-release/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: eas-release
+description: 'Guides safe Expo EAS releases for this app, choosing OTA updates versus native builds and GitHub workflows. Use when preparing an Expo release, publishing EAS Update, running build.yml, or checking runtimeVersion safety.'
+---
+
+# EAS Release
+
+## Quick start
+
+For JavaScript, UI, or asset-only changes, keep `app.json` on `runtimeVersion` policy `appVersion`, validate locally, then publish through `.github/workflows/update.yml` or run:
+
+```bash
+eas update --auto
+```
+
+For native changes, skip OTA and trigger the production build workflow:
+
+```bash
+gh workflow run build.yml --ref main -f platform=ios -f profile=production
+```
+
+## Workflow
+
+1. Classify the change: JS/assets can use EAS Update; native dependencies, config plugins, `app.json` native fields, or generated native projects require EAS Build.
+2. Confirm `runtimeVersion` still prevents incompatible OTA updates; this repo uses the `appVersion` policy.
+3. For OTA, merge through PR to `main` and let `update.yml` publish after the native fingerprint check, or run `eas update --auto` only with a valid `EXPO_TOKEN`.
+4. For native releases, use `build.yml` with `profile=production`; prioritize iOS, keep web unaffected, and treat Android as best-effort.
+5. Monitor EAS build/update output and roll back or republish if production health regresses.
+
+## Validation
+
+Run before release changes merge:
+
+```bash
+bun run lint
+bun run typecheck
+bunx expo-doctor@latest
+```
+
+Verify the release path matches the change type and that required workflow secrets are present without printing token values.
+
+## Guardrails
+
+- Never ship native dependency or config-plugin changes with OTA only.
+- Do not push directly to `main`; releases must come from reviewed PRs.
+- Do not commit EAS, Apple, Google, or Supabase secrets.
+- Keep release automation aligned with Bun, Expo SDK 54, and the existing GitHub workflow files.

--- a/.github/skills/new-screen-route/SKILL.md
+++ b/.github/skills/new-screen-route/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: new-screen-route
+description: 'Adds Expo Router screens that match this app’s tab, stack, modal, and typed route conventions. Use when creating a new screen, adding a route under src/app, editing (tabs), or wiring navigation in _layout.tsx.'
+---
+
+# New Screen Route
+
+## Quick start
+
+Add screens under `src/app/`. Put primary navigation in `src/app/(tabs)/<name>.tsx`; put modal or stack screens beside the root `_layout.tsx`, such as `src/app/weight.tsx`.
+
+Register route options in the nearest `_layout.tsx` and navigate with expo-router typed routes rather than ad-hoc string paths.
+
+## Workflow
+
+1. Choose the route shape: `(tabs)` for core tabs, `[id].tsx` for dynamic details, or a root stack/modal file for focused flows.
+2. Create a small screen component using React Native primitives, project design tokens, and `@/*` imports.
+3. Register stack or tab options in `src/app/_layout.tsx` or `src/app/(tabs)/_layout.tsx`; keep headers and presentation consistent with nearby screens.
+4. Link to the screen with `Link`, `router.push`, or `router.navigate` using typed routes, including explicit params for dynamic paths.
+5. Keep data access in stores/hooks; screens should compose UI and call existing domain APIs.
+
+## Validation
+
+Run:
+
+```bash
+bun run lint
+bun run typecheck
+bunx jest --runInBand
+```
+
+Also smoke-test the route on iOS simulator and web when navigation, layout, or platform behavior changes.
+
+## Guardrails
+
+- Do not duplicate route names across groups unless Expo Router semantics require it.
+- Keep HealthKit or native-only UI hidden or gracefully degraded off iOS.
+- Prefer platform-specific files for major divergence; use small inline gates only for simple layout differences.
+- Do not add Android-only navigation or native dependencies for a screen unless they also serve iOS or web.

--- a/.github/skills/platform-gate/SKILL.md
+++ b/.github/skills/platform-gate/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: platform-gate
+description: 'Applies repo-specific iOS, web, and Android platform gates with deterministic fallbacks. Use when touching HealthKit, native modules, Platform.OS checks, Platform.select values, or mock data generation.'
+---
+
+# Platform Gate
+
+## Quick start
+
+Gate iOS-only features explicitly and provide deterministic fallback data elsewhere:
+
+```ts
+const enabled = Platform.OS === 'ios'
+const padding = Platform.select({ ios: 20, web: 16, default: 14 })
+```
+
+Use existing mock adapters where possible; for new domains, add a deterministic `generateMockData` helper and test it.
+
+## Workflow
+
+1. Identify the platform dependency: HealthKit and native modules are iOS-first; web must not crash; Android is best-effort.
+2. Use `Platform.select` for style, spacing, and config values instead of scattered branching.
+3. Use `Platform.OS === 'ios'` before requesting native permissions, rendering HealthKit-only UI, or calling iOS-only adapters.
+4. Provide a deterministic fallback adapter or `generateMockData` path for web, tests, and unsupported devices.
+5. For large differences, split files with `.ios.tsx`, `.web.tsx`, or `.native.tsx` rather than growing conditional components.
+
+## Validation
+
+Run:
+
+```bash
+bun run lint
+bun run typecheck
+bunx jest --runInBand
+```
+
+For UI changes, smoke-test iOS and web. Add tests that assert unsupported platforms use the fallback path and do not call native-only APIs.
+
+## Guardrails
+
+- Never import or execute unsupported native APIs on web without a safe module boundary.
+- Do not show HealthKit setup controls unless the iOS adapter is available.
+- Keep mock data deterministic; avoid `Math.random()` for fallback snapshots.
+- Prefer iOS and web correctness over Android parity, but avoid knowingly breaking Android.

--- a/scripts/validate-ai-artifacts.ts
+++ b/scripts/validate-ai-artifacts.ts
@@ -46,7 +46,30 @@ const requiredSkills: RequiredSkill[] = [
   },
 ]
 
-const requiredAgents: RequiredAgent[] = []
+const requiredAgents: RequiredAgent[] = [
+  {
+    file: 'healthkit-data-pipeline-auditor.agent.md',
+    name: 'HealthKit Data Pipeline Auditor',
+    readOnly: true,
+    requiredTerms: [
+      'daily_health_snapshots',
+      'generateMockData',
+      'READ_PERMISSIONS',
+    ],
+  },
+  {
+    file: 'supabase-schema-reviewer.agent.md',
+    name: 'Supabase Schema Reviewer',
+    readOnly: true,
+    requiredTerms: ['RLS', 'database.types.ts', 'validators.ts'],
+  },
+  {
+    file: 'expo-dependency-auditor.agent.md',
+    name: 'Expo Dependency Auditor',
+    readOnly: true,
+    requiredTerms: ['expo-doctor', 'expo install --check', '@expo/fingerprint'],
+  },
+]
 
 const deprecatedToolNames = new Set([
   'codebase',

--- a/scripts/validate-ai-artifacts.ts
+++ b/scripts/validate-ai-artifacts.ts
@@ -28,6 +28,22 @@ const requiredSkills: RequiredSkill[] = [
     name: 'supabase-migration',
     requiredTerms: ['RLS', 'generate-types', 'validators'],
   },
+  {
+    name: 'eas-release',
+    requiredTerms: ['eas update --auto', 'build.yml', 'runtimeVersion'],
+  },
+  {
+    name: 'new-screen-route',
+    requiredTerms: ['(tabs)', '_layout.tsx', 'typed routes'],
+  },
+  {
+    name: 'platform-gate',
+    requiredTerms: [
+      "Platform.OS === 'ios'",
+      'Platform.select',
+      'generateMockData',
+    ],
+  },
 ]
 
 const requiredAgents: RequiredAgent[] = []


### PR DESCRIPTION
## Summary
- add EAS release, new screen route, and platform gate skills
- extend the AI artifact validator to cover the delivery/platform skills

## Validation
- bun run validate:ai-artifacts
- bun run lint
- bun run typecheck