### PR TITLE
chore(testing): define Expo quality gates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,10 +130,15 @@ This project targets **iOS and Web as primary platforms**, with **minimal Androi
 ## Build and Testing Expectations
 
 - Use development builds for production-grade app workflows; do not rely solely on Expo Go.
-- Run lint and type checks before merge:
-  - `bunx eslint .`
-  - `bun run typecheck`
-- Keep tests passing (`bunx jest`) for changed areas.
+- Treat testing tools as explicit Modules with CLI Interfaces:
+  - PR quality gate: `bun run quality:pr`
+  - Expo compatibility: `bun run expo:check` and `bun run expo:doctor`
+  - Unit/component Implementation: `bun run test:unit`
+  - Web smoke Adapter: `bun run test:e2e:web`
+  - Native smoke Adapter: `bun run test:e2e:maestro:ios` / `bun run test:e2e:maestro:android`
+- Keep PR CI focused on high-Leverage, high-Locality checks: Expo compatibility, lint, typecheck, and unit/component tests.
+- Keep Playwright web smoke tests small and focused on the browser Seam; do not duplicate Jest assertions.
+- Keep Maestro as a native simulator/device Adapter for local, release, or dedicated native CI. Do not make it mandatory PR CI unless the runner support is reliable.
 - Pre-commit hooks (Husky + lint-staged) auto-run ESLint `--fix` on staged `.ts`/`.tsx`/`.js`/`.jsx`/`.mjs` files.
 
 ## Issue and Debugging Hygiene

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    name: Lint, Typecheck & Test
+    name: PR Quality Gates
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -32,14 +32,20 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Check Expo dependency alignment
+        run: bun run expo:check
+
+      - name: Run Expo Doctor
+        run: bun run expo:doctor
+
       - name: Run linter
         run: bun run lint
 
       - name: Run typecheck
         run: bun run typecheck
 
-      - name: Run tests
-        run: bunx jest --no-watchman
+      - name: Run unit tests
+        run: bun run test:unit -- --runInBand --no-watchman
 
   preview:
     name: EAS Update (Preview)

--- a/README.md
+++ b/README.md
@@ -46,9 +46,16 @@ bun run web            # Web browser (Metro bundler)
 
 | Command                  | Description                              |
 | ------------------------ | ---------------------------------------- |
+| `bun run quality:pr`     | PR gate: Expo checks, lint, typecheck, unit tests |
+| `bun run expo:check`     | Verify Expo SDK dependency alignment     |
+| `bun run expo:doctor`    | Run Expo Doctor diagnostics              |
 | `bun run lint`           | ESLint (flat config + Prettier)          |
 | `bun run typecheck`      | TypeScript `--noEmit`                    |
 | `bun run test`           | Jest via jest-expo                       |
+| `bun run test:unit`      | Explicit Jest unit/component Interface   |
+| `bun run test:e2e:web`   | Playwright Expo web smoke test           |
+| `bun run test:e2e:maestro:ios` | Maestro iOS native smoke flows     |
+| `bun run test:e2e:maestro:android` | Maestro Android native smoke flows |
 | `bun run test:watch`     | Jest in watch mode                       |
 | `bun run db:debug`       | Verify Supabase connectivity             |
 | `bun run generate-types` | Regenerate Supabase DB types             |
@@ -182,13 +189,16 @@ TypeScript types (`ExerciseRow`, `ExerciseDetail`, `Cardio`) are derived from th
 
 GitHub Actions workflows in `.github/workflows/`:
 
-| Workflow    | Trigger         | Description                                      |
-| ----------- | --------------- | ------------------------------------------------ |
-| **preview** | Pull request    | Lint + typecheck + test, then EAS Update preview |
-| **update**  | Push to `main`  | EAS Update production (aborts on native changes) |
-| **build**   | Manual dispatch | EAS Build (iOS/Android, any profile)             |
+| Workflow    | Trigger         | Description                                            |
+| ----------- | --------------- | ------------------------------------------------------ |
+| **preview** | Pull request    | Expo compatibility, lint, typecheck, unit tests, EAS preview |
+| **update**  | Push to `main`  | EAS Update production (aborts on native changes)       |
+| **build**   | Manual dispatch | EAS Build (iOS/Android, any profile)                   |
 
-The **preview** workflow runs on every PR and gates merges on passing lint, typecheck, and tests.
+The **preview** workflow runs on every PR and gates merges on `bun run expo:check`,
+`bun run expo:doctor`, `bun run lint`, `bun run typecheck`, and `bun run test:unit`.
+This keeps the PR Interface aligned with Expo SDK compatibility without forcing
+device/simulator-only Adapters into GitHub-hosted runners.
 
 ## 8) Native Workflow (CNG)
 
@@ -215,24 +225,66 @@ bun run native:reset      # rm -rf ios android && prebuild --clean
 
 HealthKit features (`DailySteps`, `HealthMetrics`) are gated with `Platform.OS === 'ios'` and return `null` on other platforms.
 
-## 10) Testing
+## 10) Testing & Quality Gates
+
+The testing stack is split into explicit Modules with clear Interfaces. Each
+Implementation is chosen for the Depth where it has the most Leverage, while
+keeping Locality high so failures point at the smallest useful Seam.
+
+| Module | Interface | Implementation | Depth / Seam |
+| ------ | --------- | -------------- | ------------ |
+| Expo compatibility | `bun run expo:check`, `bun run expo:doctor` | Expo CLI / Expo Doctor | SDK dependency and config Seam; mandatory PR Leverage |
+| Unit & component | `bun run test:unit` | Jest + jest-expo + Testing Library | Stores, hooks, utilities, and component Seams close to source |
+| Web smoke | `bun run test:e2e:web` | Playwright + Expo web dev server | Browser Adapter for the app shell; optional local/CI smoke |
+| Native smoke | `bun run test:e2e:maestro:ios`, `bun run test:e2e:maestro:android` | Maestro flows | Simulator/device Adapter for release and native checks |
+
+Run the PR gate locally before opening a pull request:
+
+```bash
+bun run quality:pr
+```
 
 ### Unit & Component Tests (Jest)
 
 ```bash
 bun run test             # run all tests
+bun run test:unit        # explicit unit/component gate
 bun run test:watch       # watch mode
 ```
 
 Test files live alongside source code in `__tests__/` directories.
+Jest ignores `e2e/`; that directory is owned by the Playwright Interface.
 
-### E2E Tests (Maestro)
+### Web E2E Smoke (Playwright)
+
+```bash
+bun run test:e2e:web
+```
+
+The Playwright smoke test starts Expo web through `playwright.config.ts` and
+asserts that the app shell renders at the configured `baseURL`. Keep this Module
+small: it protects the browser Adapter Seam without duplicating Jest coverage.
+If the local browser binary is missing, install the script's browser with
+`bunx playwright install chromium`.
+
+### Native E2E Smoke (Maestro)
 
 Maestro flows live in `.maestro/flows/` with platform-specific directories:
 
 - `ios/` — HealthKit home, settings HealthKit
 - `android/` — workouts, app navigation
 - `common/` — startup flow
+
+Run them against a prepared development build on a simulator/device:
+
+```bash
+bun run test:e2e:maestro:ios
+bun run test:e2e:maestro:android
+```
+
+Maestro is intentionally not mandatory PR CI unless the runner has reliable
+native simulator/device support. These scripts require the Maestro CLI to be
+installed locally or on the dedicated native runner.
 
 ## 11) Branching & Workflow
 

--- a/e2e/app-smoke.spec.ts
+++ b/e2e/app-smoke.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test'
+
+test.setTimeout(60_000)
+
+test('loads the Expo web app shell', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+  await expect(page.locator('body')).toBeVisible()
+  await expect(
+    page
+      .getByText(/Fitness Metrics|Workout Progress|Workouts|Settings/)
+      .first(),
+  ).toBeVisible({ timeout: 30_000 })
+})

--- a/package.json
+++ b/package.json
@@ -13,10 +13,17 @@
     "ios": "bunx expo run:ios",
     "web": "bunx expo start --web",
     "test": "bunx jest",
+    "test:unit": "bunx jest",
+    "test:e2e:web": "bunx playwright test --project=chromium",
+    "test:e2e:maestro:ios": "maestro test .maestro/flows/ios",
+    "test:e2e:maestro:android": "maestro test .maestro/flows/android",
     "test:watch": "bunx jest --watch",
     "lint": "bunx eslint .",
     "typecheck": "tsc --noEmit",
     "validate:ai-artifacts": "bun run scripts/validate-ai-artifacts.ts",
+    "expo:check": "bunx expo install --check",
+    "expo:doctor": "bunx expo-doctor@latest",
+    "quality:pr": "bun run expo:check && bun run expo:doctor && bun run lint && bun run typecheck && bun run test:unit -- --runInBand --no-watchman",
     "db:debug": "bun run scripts/debug-db.ts",
     "generate-types": "supabase gen types typescript --project-id \"$EXPO_PUBLIC_SUPABASE_PROJECT_ID\" --schema public > src/lib/database.types.ts",
     "db:migrate": "supabase db push",
@@ -31,6 +38,10 @@
     ],
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|react-native-tab-view|react-native-pager-view|uuid)"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/e2e/"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add explicit testing/tooling Interfaces: `quality:pr`, Expo compatibility checks, Jest unit tests, Playwright web smoke, and Maestro native smoke Adapters.
- Gate PR preview CI on Expo dependency alignment, Expo Doctor, lint, typecheck, and serialized unit tests.
- Add a small Playwright web smoke test and keep Jest/Playwright separated at the `e2e/` Seam.
- Document test Modules, Implementations, Depth, Leverage, and Locality in README and Copilot instructions.

## Architecture notes
- Unit/component Module: Jest Implementation through `bun run test:unit`, high-Locality source Seam.
- Expo compatibility Module: Expo CLI/Doctor Implementation through `bun run expo:check` and `bun run expo:doctor`, high-Leverage PR Seam.
- Web smoke Module: Playwright Implementation through `bun run test:e2e:web`, browser Adapter for the Expo web shell.
- Native smoke Module: Maestro Implementation through iOS/Android scripts, simulator/device Adapter kept out of mandatory PR CI.

## Validation
- ✅ `bun run quality:pr` (lint reports existing warnings in `src/app/steps.tsx:40`, no errors)
- ✅ `bun run lint` (same existing warnings, no errors)
- ✅ `bun run typecheck`
- ✅ `bun run test -- --runInBand --no-watchman`
- ✅ `bun run test:e2e:web`
- ⚠️ `bunx playwright test` was attempted; the full configured suite requires the WebKit browser for the Mobile Safari project, so the committed PR Interface uses the passing Chromium web smoke.

## Review
- Blocking review completed across security, correctness, performance, deprecated APIs, and maintainability; no blocking findings remain.