### PR TITLE
fix(ci): supply placeholder Supabase env vars to visual-screenshots build

### DIFF
--- a/.github/workflows/visual-screenshots.yml
+++ b/.github/workflows/visual-screenshots.yml
@@ -59,6 +59,12 @@ jobs:
         env:
           CI: true
           EXPO_NO_TELEMETRY: 1
+          # Build-time placeholders so module-top-level Supabase init doesn't
+          # throw during static export. Visual tests don't make real network
+          # calls; the placeholders are never used at runtime.
+          EXPO_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY: placeholder_publishable_key_for_build_only
+          EXPO_PUBLIC_SUPABASE_PROJECT_ID: placeholder
 
       - name: Capture web screenshots
         id: web_visual_tests
@@ -66,6 +72,9 @@ jobs:
         env:
           CI: true
           EXPO_NO_TELEMETRY: 1
+          EXPO_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY: placeholder_publishable_key_for_build_only
+          EXPO_PUBLIC_SUPABASE_PROJECT_ID: placeholder
 
       - name: Upload screenshot artifacts
         if: always()


### PR DESCRIPTION
Follow-up to #51. The static `expo export` evaluates module-top-level code, which initializes the Supabase client and throws `supabaseUrl is required` when env vars are missing on CI.

Local runs worked because `.env.local` supplies values. CI doesn't have them, so the build step in the visual-screenshots workflow failed.

Adding non-secret placeholder env vars to the build + screenshot steps. Visual tests never make real network calls; placeholders cannot be used to access a real backend.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>