### PR TITLE
feat(workout): per-set kg + morning/evening cardio check-in

### DIFF
--- a/src/app/(tabs)/__tests__/workouts-session-test.tsx
+++ b/src/app/(tabs)/__tests__/workouts-session-test.tsx
@@ -86,6 +86,7 @@ const SESSION: WorkoutSession = {
   completedAt: '2026-01-01T01:00:00.000Z',
   status: 'complete',
   cardio: { morning: 10, evening: 0 },
+  cardioCompleted: { morning: false, evening: false },
   exerciseProgress: {
     bench: {
       detailId: 'bench',

--- a/src/app/details/[id].tsx
+++ b/src/app/details/[id].tsx
@@ -43,13 +43,15 @@ function DetailsScreen() {
   const id = Array.isArray(rawId) ? rawId[0] : rawId
   const routeTitle = Array.isArray(rawTitle) ? rawTitle[0] : rawTitle
   const { exercises } = useExerciseStore()
-  const { session, updateCardio, complete } = useWorkoutSessionStoreBase(
-    useShallow((state) => ({
-      session: id ? state.sessions[id] : undefined,
-      updateCardio: state.updateCardio,
-      complete: state.complete,
-    })),
-  )
+  const { session, updateCardio, toggleCardioDone, complete } =
+    useWorkoutSessionStoreBase(
+      useShallow((state) => ({
+        session: id ? state.sessions[id] : undefined,
+        updateCardio: state.updateCardio,
+        toggleCardioDone: state.toggleCardioDone,
+        complete: state.complete,
+      })),
+    )
   const template = session ? exercises[session.templateId] : undefined
 
   const {
@@ -288,6 +290,34 @@ function DetailsScreen() {
                   >
                     Morning
                   </Text>
+                  <TouchableOpacity
+                    onPress={() => toggleCardioDone(session.id, 'morning')}
+                    activeOpacity={0.6}
+                    accessibilityLabel={`Mark morning cardio ${session.cardioCompleted.morning ? 'incomplete' : 'complete'}`}
+                    accessibilityRole="checkbox"
+                    accessibilityState={{
+                      checked: session.cardioCompleted.morning,
+                    }}
+                    style={[
+                      styles.cardioDoneBtn,
+                      {
+                        borderColor: session.cardioCompleted.morning
+                          ? successColor
+                          : borderColor,
+                        backgroundColor: session.cardioCompleted.morning
+                          ? `${successColor}20`
+                          : 'transparent',
+                      },
+                    ]}
+                  >
+                    {session.cardioCompleted.morning ? (
+                      <Ionicons
+                        name="checkmark"
+                        size={18}
+                        color={successColor}
+                      />
+                    ) : null}
+                  </TouchableOpacity>
                   <View style={styles.cardioStepperRow}>
                     <TouchableOpacity
                       onPress={() =>
@@ -356,6 +386,34 @@ function DetailsScreen() {
                   >
                     Evening
                   </Text>
+                  <TouchableOpacity
+                    onPress={() => toggleCardioDone(session.id, 'evening')}
+                    activeOpacity={0.6}
+                    accessibilityLabel={`Mark evening cardio ${session.cardioCompleted.evening ? 'incomplete' : 'complete'}`}
+                    accessibilityRole="checkbox"
+                    accessibilityState={{
+                      checked: session.cardioCompleted.evening,
+                    }}
+                    style={[
+                      styles.cardioDoneBtn,
+                      {
+                        borderColor: session.cardioCompleted.evening
+                          ? successColor
+                          : borderColor,
+                        backgroundColor: session.cardioCompleted.evening
+                          ? `${successColor}20`
+                          : 'transparent',
+                      },
+                    ]}
+                  >
+                    {session.cardioCompleted.evening ? (
+                      <Ionicons
+                        name="checkmark"
+                        size={18}
+                        color={successColor}
+                      />
+                    ) : null}
+                  </TouchableOpacity>
                   <View style={styles.cardioStepperRow}>
                     <TouchableOpacity
                       onPress={() =>
@@ -590,6 +648,14 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '600',
     flex: 1,
+  },
+  cardioDoneBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: 8,
+    borderWidth: 1.5,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   cardioStepperRow: {
     flexDirection: 'row',

--- a/src/components/WorkoutDetail.tsx
+++ b/src/components/WorkoutDetail.tsx
@@ -19,8 +19,6 @@ import Animated, {
 } from 'react-native-reanimated'
 import { useShallow } from 'zustand/react/shallow'
 
-const WEIGHT_STEP = 2.5
-
 type WorkoutDetailProps = {
   item: ExerciseDetailTemplate
   sessionId: string
@@ -39,14 +37,13 @@ export default function WorkoutDetail({
   onSetUncompleted,
 }: WorkoutDetailProps) {
   const router = useRouter()
-  const { progress, toggleSet, setWeightForExercise } =
-    useWorkoutSessionStoreBase(
-      useShallow((state) => ({
-        progress: state.sessions[sessionId]?.exerciseProgress[item.id],
-        toggleSet: state.toggleSet,
-        setWeightForExercise: state.setWeightForExercise,
-      })),
-    )
+  const { progress, toggleSet, setWeightForSet } = useWorkoutSessionStoreBase(
+    useShallow((state) => ({
+      progress: state.sessions[sessionId]?.exerciseProgress[item.id],
+      toggleSet: state.toggleSet,
+      setWeightForSet: state.setWeightForSet,
+    })),
+  )
 
   const defaultSets = progress?.setsOverride ?? item.sets
   const effectiveReps = progress?.repsOverride ?? item.reps
@@ -58,8 +55,16 @@ export default function WorkoutDetail({
     progress?.selectedSets ?? Array.from({ length: defaultSets }, () => false)
   const weights =
     progress?.weightPerSet ?? Array.from({ length: defaultSets }, () => 0)
-  const displayWeight = weights[0] ?? 0
   const completedCount = selectedCircles.filter(Boolean).length
+  // Top-line weight summary: the most-recently entered (highest-index)
+  // non-zero kg value, falling back to the first set's weight.
+  const summaryWeight = (() => {
+    for (let i = weights.length - 1; i >= 0; i--) {
+      const w = weights[i] ?? 0
+      if (w > 0) return w
+    }
+    return 0
+  })()
   const scale = useSharedValue(1)
   const progressAnim = useSharedValue(
     defaultSets > 0 ? completedCount / defaultSets : 0,
@@ -72,24 +77,17 @@ export default function WorkoutDetail({
     )
   }, [completedCount, defaultSets, progressAnim])
 
-  const adjustWeight = useCallback(
-    (delta: number) => {
-      const newWeight = Math.max(0, displayWeight + delta)
-      setWeightForExercise(sessionId, item.id, newWeight)
-    },
-    [displayWeight, item.id, sessionId, setWeightForExercise],
-  )
-
   const handleWeightInput = useCallback(
-    (text: string) => {
+    (setIdx: number, text: string) => {
       const parsed = parseFloat(text)
-      setWeightForExercise(
+      setWeightForSet(
         sessionId,
         item.id,
+        setIdx,
         Number.isNaN(parsed) ? 0 : Math.max(0, parsed),
       )
     },
-    [item.id, sessionId, setWeightForExercise],
+    [item.id, sessionId, setWeightForSet],
   )
 
   const toggleCircle = (idx: number) => {
@@ -194,9 +192,9 @@ export default function WorkoutDetail({
             <Text style={[styles.repsInfo, { color: subtitleText }]}>
               {defaultSets} × {effectiveReps} reps
             </Text>
-            {displayWeight > 0 && (
+            {summaryWeight > 0 && (
               <Text style={[styles.repsInfo, { color: subtitleText }]}>
-                · {displayWeight} kg
+                · up to {summaryWeight} kg
               </Text>
             )}
           </View>
@@ -217,76 +215,63 @@ export default function WorkoutDetail({
         </Text>
       </View>
 
-      {/* Weight adjuster */}
-      <View style={styles.weightRow}>
-        <TouchableOpacity
-          onPress={() => adjustWeight(-WEIGHT_STEP)}
-          style={[styles.weightBtn, { borderColor }]}
-          activeOpacity={0.6}
-          disabled={displayWeight <= 0}
-        >
-          <Text
-            style={[
-              styles.weightBtnText,
-              { color: displayWeight > 0 ? textColor : subtitleText },
-            ]}
-          >
-            −
-          </Text>
-        </TouchableOpacity>
-        <View style={styles.weightCenter}>
-          <TextInput
-            style={[styles.weightValue, { color: textColor }]}
-            value={displayWeight > 0 ? String(displayWeight) : ''}
-            placeholder="0"
-            placeholderTextColor={subtitleText}
-            keyboardType="numeric"
-            onChangeText={handleWeightInput}
-            selectTextOnFocus
-          />
-          <Text style={[styles.weightUnit, { color: subtitleText }]}>kg</Text>
-        </View>
-        <TouchableOpacity
-          onPress={() => adjustWeight(WEIGHT_STEP)}
-          style={[styles.weightBtn, { borderColor }]}
-          activeOpacity={0.6}
-        >
-          <Text style={[styles.weightBtnText, { color: textColor }]}>+</Text>
-        </TouchableOpacity>
-      </View>
-
-      {/* Row 2: Set pills */}
-      <Animated.View style={[styles.pillRow, bounceStyle]}>
+      {/* Per-set columns: kg input on top, tappable pill below */}
+      <Animated.View style={[styles.columnRow, bounceStyle]}>
         {Array.from({ length: defaultSets }).map((_, i) => {
           const done = selectedCircles[i]
+          const kg = weights[i] ?? 0
           return (
-            <TouchableOpacity
-              key={i}
-              activeOpacity={0.6}
-              onPress={() => toggleCircle(i)}
-              style={[
-                styles.pill,
-                {
-                  backgroundColor: done ? successInactive : 'transparent',
-                  borderColor: done ? successColor : borderColor,
-                },
-              ]}
-            >
-              {done ? (
-                <Text style={[styles.pillCheck, { color: successColor }]}>
-                  ✓
-                </Text>
-              ) : (
-                <View style={styles.pillContent}>
-                  <Text style={[styles.pillLabel, { color: subtitleText }]}>
-                    S{i + 1}
+            <View key={i} style={styles.setColumn}>
+              <View
+                style={[
+                  styles.kgWrap,
+                  {
+                    borderColor: done ? successColor : borderColor,
+                    backgroundColor: done ? `${successColor}10` : 'transparent',
+                  },
+                ]}
+              >
+                <TextInput
+                  style={[styles.kgInput, { color: textColor }]}
+                  value={kg > 0 ? String(kg) : ''}
+                  placeholder="0"
+                  placeholderTextColor={subtitleText}
+                  keyboardType="numeric"
+                  onChangeText={(t) => handleWeightInput(i, t)}
+                  selectTextOnFocus
+                  accessibilityLabel={`Weight for set ${i + 1}`}
+                />
+                <Text style={[styles.kgUnit, { color: subtitleText }]}>kg</Text>
+              </View>
+              <TouchableOpacity
+                activeOpacity={0.6}
+                onPress={() => toggleCircle(i)}
+                accessibilityLabel={`Set ${i + 1}, ${done ? 'completed' : 'incomplete'}`}
+                accessibilityRole="button"
+                style={[
+                  styles.pill,
+                  {
+                    backgroundColor: done ? successInactive : 'transparent',
+                    borderColor: done ? successColor : borderColor,
+                  },
+                ]}
+              >
+                {done ? (
+                  <Text style={[styles.pillCheck, { color: successColor }]}>
+                    ✓
                   </Text>
-                  <Text style={[styles.pillText, { color: textColor }]}>
-                    {effectiveReps}
-                  </Text>
-                </View>
-              )}
-            </TouchableOpacity>
+                ) : (
+                  <View style={styles.pillContent}>
+                    <Text style={[styles.pillLabel, { color: subtitleText }]}>
+                      S{i + 1}
+                    </Text>
+                    <Text style={[styles.pillText, { color: textColor }]}>
+                      {effectiveReps}
+                    </Text>
+                  </View>
+                )}
+              </TouchableOpacity>
+            </View>
           )
         })}
       </Animated.View>
@@ -369,52 +354,42 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     fontVariant: ['tabular-nums'],
   },
-  /* Weight adjuster */
-  weightRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 12,
-    marginBottom: 14,
-  },
-  weightBtn: {
-    width: 36,
-    height: 36,
-    borderRadius: 10,
-    borderWidth: 1.5,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  weightBtnText: {
-    fontSize: 20,
-    fontWeight: '600',
-    lineHeight: 22,
-  },
-  weightCenter: {
-    flexDirection: 'row',
-    alignItems: 'baseline',
-    gap: 4,
-  },
-  weightValue: {
-    fontSize: 22,
-    fontWeight: '800',
-    fontVariant: ['tabular-nums'],
-    minWidth: 40,
-    textAlign: 'center',
-    padding: 0,
-  },
-  weightUnit: {
-    fontSize: 13,
-    fontWeight: '600',
-  },
-  /* Row 2 */
-  pillRow: {
+  /* Per-set column row */
+  columnRow: {
     flexDirection: 'row',
     gap: 8,
+    flexWrap: 'wrap',
+  },
+  setColumn: {
+    alignItems: 'center',
+    gap: 6,
+  },
+  kgWrap: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'center',
+    gap: 2,
+    minWidth: 56,
+    paddingHorizontal: 6,
+    paddingVertical: 6,
+    borderRadius: 10,
+    borderWidth: 1.5,
+  },
+  kgInput: {
+    fontSize: 15,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+    textAlign: 'center',
+    minWidth: 24,
+    padding: 0,
+  },
+  kgUnit: {
+    fontSize: 10,
+    fontWeight: '600',
   },
   pill: {
     height: 44,
-    minWidth: 44,
+    minWidth: 56,
     borderRadius: 12,
     borderWidth: 1.5,
     justifyContent: 'center',

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -109,6 +109,11 @@ export const exerciseProgressSchema = z.object({
   variationOverride: z.string().nullable().optional(),
 })
 
+export const cardioCompletedSchema = z.object({
+  morning: z.boolean(),
+  evening: z.boolean(),
+})
+
 export const workoutSessionAggregateSchema = z.object({
   id: z.string(),
   templateId: z.string(),
@@ -116,6 +121,7 @@ export const workoutSessionAggregateSchema = z.object({
   completedAt: z.string().nullable(),
   exerciseProgress: z.record(z.string(), exerciseProgressSchema),
   cardio: cardioSchema,
+  cardioCompleted: cardioCompletedSchema,
   status: z.enum(['in-progress', 'complete']),
 })
 

--- a/src/stores/WorkoutSessionStore.ts
+++ b/src/stores/WorkoutSessionStore.ts
@@ -16,10 +16,17 @@ interface SessionState {
     detailId: string,
     kg: number,
   ) => void
+  setWeightForSet: (
+    sessionId: string,
+    detailId: string,
+    setIdx: number,
+    kg: number,
+  ) => void
   updateCardio: (
     sessionId: string,
     cardio: { morning: number; evening: number },
   ) => void
+  toggleCardioDone: (sessionId: string, slot: 'morning' | 'evening') => void
   updateExerciseOverrides: (
     sessionId: string,
     detailId: string,
@@ -127,6 +134,7 @@ export const useWorkoutSessionStoreBase = create<SessionState>((set, get) => ({
       completedAt: null,
       exerciseProgress: createProgress(template),
       cardio: { ...template.cardio },
+      cardioCompleted: { morning: false, evening: false },
       status: 'in-progress',
     }
 
@@ -156,7 +164,25 @@ export const useWorkoutSessionStoreBase = create<SessionState>((set, get) => ({
       }
 
       const selectedSets = [...progress.selectedSets]
-      selectedSets[setIdx] = !selectedSets[setIdx]
+      const wasSelected = selectedSets[setIdx]
+      selectedSets[setIdx] = !wasSelected
+
+      // When marking a set DONE (not undoing), cascade its weight to the
+      // next blank set so the user only types kg once per "weight change".
+      // We never overwrite a non-zero weight the user already entered.
+      let weightPerSet = progress.weightPerSet
+      if (!wasSelected) {
+        const currentKg = weightPerSet[setIdx] ?? 0
+        const nextIdx = setIdx + 1
+        if (
+          currentKg > 0 &&
+          nextIdx < weightPerSet.length &&
+          (weightPerSet[nextIdx] ?? 0) === 0
+        ) {
+          weightPerSet = [...weightPerSet]
+          weightPerSet[nextIdx] = currentKg
+        }
+      }
 
       return {
         sessions: {
@@ -168,6 +194,7 @@ export const useWorkoutSessionStoreBase = create<SessionState>((set, get) => ({
               [detailId]: {
                 ...progress,
                 selectedSets,
+                weightPerSet,
               },
             },
           },
@@ -200,6 +227,40 @@ export const useWorkoutSessionStoreBase = create<SessionState>((set, get) => ({
     })
   },
 
+  setWeightForSet: (sessionId, detailId, setIdx, kg) => {
+    set((state) => {
+      const session = state.sessions[sessionId]
+      const progress = session?.exerciseProgress[detailId]
+      if (
+        !session ||
+        !progress ||
+        setIdx < 0 ||
+        setIdx >= progress.weightPerSet.length
+      ) {
+        return state
+      }
+
+      const weightPerSet = [...progress.weightPerSet]
+      weightPerSet[setIdx] = Math.max(0, kg)
+
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: {
+            ...session,
+            exerciseProgress: {
+              ...session.exerciseProgress,
+              [detailId]: {
+                ...progress,
+                weightPerSet,
+              },
+            },
+          },
+        },
+      }
+    })
+  },
+
   updateCardio: (sessionId, cardio) => {
     set((state) => {
       const session = state.sessions[sessionId]
@@ -213,6 +274,26 @@ export const useWorkoutSessionStoreBase = create<SessionState>((set, get) => ({
             cardio: {
               morning: Math.max(0, cardio.morning),
               evening: Math.max(0, cardio.evening),
+            },
+          },
+        },
+      }
+    })
+  },
+
+  toggleCardioDone: (sessionId, slot) => {
+    set((state) => {
+      const session = state.sessions[sessionId]
+      if (!session) return state
+
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: {
+            ...session,
+            cardioCompleted: {
+              ...session.cardioCompleted,
+              [slot]: !session.cardioCompleted[slot],
             },
           },
         },

--- a/src/stores/__tests__/WorkoutSessionStore-test.ts
+++ b/src/stores/__tests__/WorkoutSessionStore-test.ts
@@ -74,6 +74,10 @@ describe('WorkoutSessionStore', () => {
         false,
       ])
       expect(session.exerciseProgress.press.weightPerSet).toEqual([0, 0, 0])
+      expect(session.cardioCompleted).toEqual({
+        morning: false,
+        evening: false,
+      })
     })
 
     it('returns the active session for the same template without overwriting progress', () => {
@@ -132,6 +136,103 @@ describe('WorkoutSessionStore', () => {
         false,
       ])
     })
+
+    it('cascades the completed set weight to the next blank set', () => {
+      const session = useWorkoutSessionStoreBase
+        .getState()
+        .startSession(TEMPLATE)
+      useWorkoutSessionStoreBase
+        .getState()
+        .setWeightForSet(session.id, 'bench', 0, 60)
+
+      useWorkoutSessionStoreBase.getState().toggleSet(session.id, 'bench', 0)
+
+      const updated = useWorkoutSessionStoreBase.getState().sessions[session.id]
+      expect(updated.exerciseProgress.bench.weightPerSet).toEqual([
+        60, 60, 0, 0,
+      ])
+    })
+
+    it('does not overwrite an existing weight when cascading', () => {
+      const session = useWorkoutSessionStoreBase
+        .getState()
+        .startSession(TEMPLATE)
+      useWorkoutSessionStoreBase
+        .getState()
+        .setWeightForSet(session.id, 'bench', 0, 60)
+      useWorkoutSessionStoreBase
+        .getState()
+        .setWeightForSet(session.id, 'bench', 1, 65)
+
+      useWorkoutSessionStoreBase.getState().toggleSet(session.id, 'bench', 0)
+
+      const updated = useWorkoutSessionStoreBase.getState().sessions[session.id]
+      expect(updated.exerciseProgress.bench.weightPerSet).toEqual([
+        60, 65, 0, 0,
+      ])
+    })
+
+    it('does not cascade when undoing a set', () => {
+      const session = useWorkoutSessionStoreBase
+        .getState()
+        .startSession(TEMPLATE)
+      useWorkoutSessionStoreBase
+        .getState()
+        .setWeightForSet(session.id, 'bench', 0, 60)
+      // Toggle on -> cascades 60 to set 1
+      useWorkoutSessionStoreBase.getState().toggleSet(session.id, 'bench', 0)
+      // Toggle off -> must NOT cascade again
+      useWorkoutSessionStoreBase.getState().toggleSet(session.id, 'bench', 0)
+
+      const updated = useWorkoutSessionStoreBase.getState().sessions[session.id]
+      expect(updated.exerciseProgress.bench.selectedSets[0]).toBe(false)
+      expect(updated.exerciseProgress.bench.weightPerSet).toEqual([
+        60, 60, 0, 0,
+      ])
+    })
+  })
+
+  describe('setWeightForSet()', () => {
+    it('updates only the requested set index', () => {
+      const session = useWorkoutSessionStoreBase
+        .getState()
+        .startSession(TEMPLATE)
+
+      useWorkoutSessionStoreBase
+        .getState()
+        .setWeightForSet(session.id, 'bench', 2, 42.5)
+
+      const updated = useWorkoutSessionStoreBase.getState().sessions[session.id]
+      expect(updated.exerciseProgress.bench.weightPerSet).toEqual([
+        0, 0, 42.5, 0,
+      ])
+    })
+
+    it('clamps negative weights to zero', () => {
+      const session = useWorkoutSessionStoreBase
+        .getState()
+        .startSession(TEMPLATE)
+
+      useWorkoutSessionStoreBase
+        .getState()
+        .setWeightForSet(session.id, 'bench', 0, -10)
+
+      const updated = useWorkoutSessionStoreBase.getState().sessions[session.id]
+      expect(updated.exerciseProgress.bench.weightPerSet[0]).toBe(0)
+    })
+
+    it('ignores out-of-range indexes', () => {
+      const session = useWorkoutSessionStoreBase
+        .getState()
+        .startSession(TEMPLATE)
+
+      useWorkoutSessionStoreBase
+        .getState()
+        .setWeightForSet(session.id, 'bench', 99, 50)
+
+      const updated = useWorkoutSessionStoreBase.getState().sessions[session.id]
+      expect(updated.exerciseProgress.bench.weightPerSet).toEqual([0, 0, 0, 0])
+    })
   })
 
   describe('setWeightForExercise()', () => {
@@ -165,6 +266,50 @@ describe('WorkoutSessionStore', () => {
       expect(
         useWorkoutSessionStoreBase.getState().sessions[session.id].cardio,
       ).toEqual({ morning: 25, evening: 0 })
+    })
+  })
+
+  describe('toggleCardioDone()', () => {
+    it('flips just the requested slot', () => {
+      const session = useWorkoutSessionStoreBase
+        .getState()
+        .startSession(TEMPLATE)
+
+      useWorkoutSessionStoreBase
+        .getState()
+        .toggleCardioDone(session.id, 'morning')
+
+      expect(
+        useWorkoutSessionStoreBase.getState().sessions[session.id]
+          .cardioCompleted,
+      ).toEqual({ morning: true, evening: false })
+
+      useWorkoutSessionStoreBase
+        .getState()
+        .toggleCardioDone(session.id, 'evening')
+
+      expect(
+        useWorkoutSessionStoreBase.getState().sessions[session.id]
+          .cardioCompleted,
+      ).toEqual({ morning: true, evening: true })
+    })
+
+    it('toggles back off on a second call', () => {
+      const session = useWorkoutSessionStoreBase
+        .getState()
+        .startSession(TEMPLATE)
+
+      useWorkoutSessionStoreBase
+        .getState()
+        .toggleCardioDone(session.id, 'morning')
+      useWorkoutSessionStoreBase
+        .getState()
+        .toggleCardioDone(session.id, 'morning')
+
+      expect(
+        useWorkoutSessionStoreBase.getState().sessions[session.id]
+          .cardioCompleted.morning,
+      ).toBe(false)
     })
   })
 

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -40,6 +40,8 @@ export interface WorkoutSession {
   completedAt: string | null
   exerciseProgress: Record<string, ExerciseProgress>
   cardio: { morning: number; evening: number }
+  /** Whether the user has manually marked each cardio block as done. */
+  cardioCompleted: { morning: boolean; evening: boolean }
   status: 'in-progress' | 'complete'
 }
 


### PR DESCRIPTION
## Summary

Two improvements to the active workout screen:

1. **Per-set weight tracking** — each set pill now has its own editable kg input. Completing a set cascades its weight forward to the next blank set as a starting value (never overwrites existing weights, never cascades on uncheck).

2. **Morning / evening cardio check-in** — adds a checkbox next to each Morning/Evening row in the cardio editor so the user can mark them done independently of the minute steppers.

Stacks on top of #56 (env-fix). Once #56 merges, GitHub will rebase this PR's diff against `main` automatically.

## Behaviour changes

### `WorkoutDetail.tsx`
- Removed the global ± kg adjuster row.
- Each set is now a vertical column: editable kg input on top, tappable pill below.
- Pill border + background turn green when the set is done; the kg input above gets a green tint as well.

### `details/[id].tsx` (cardio editor)
- New ✓ button next to "Morning" and "Evening" rows. Tap to mark done.
- Minute steppers preserved untouched — they still drive HealthKit cardio sync.

## Store changes (`WorkoutSessionStore.ts`)
- New action `setWeightForSet(sessionId, detailId, setIdx, kg)` — updates a single set's weight.
- New action `toggleCardioDone(sessionId, slot)` — flips morning/evening completion.
- `toggleSet` now cascades weight forward when checking on (never on uncheck), and never overwrites a non-zero weight.
- `startSession` initialises `cardioCompleted: { morning: false, evening: false }`.
- `setWeightForExercise` is preserved on the store for the ExerciseEdit "Default Weight" save flow.

## Type / schema changes
- `WorkoutSession` gains `cardioCompleted: { morning: boolean; evening: boolean }`.
- Matching `cardioCompletedSchema` added to `validators.ts`.

## Validation

- ✅ `bun run lint`
- ✅ `bun run typecheck`
- ✅ `bunx jest` — 154/154 (8 new tests)
- ✅ `bunx expo-doctor@latest` — 18/18

## Tests added

| Behaviour | What it asserts |
|---|---|
| `startSession` initialises `cardioCompleted` | both slots false |
| Cascade on check | set 0 done → set 1 inherits set 0's kg if blank |
| Cascade does not overwrite | pre-set set 1 weight survives toggling set 0 |
| No cascade on uncheck | undoing a set never re-cascades |
| `setWeightForSet` single-index update | only the requested set changes |
| `setWeightForSet` clamp | negative weights become 0 |
| `setWeightForSet` out-of-range | bad index is a no-op |
| `toggleCardioDone` independent slots | morning and evening toggle independently |
| `toggleCardioDone` round-trip | second call un-toggles |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
